### PR TITLE
Guides as Models

### DIFF
--- a/deepppl/parser/stan.g4
+++ b/deepppl/parser/stan.g4
@@ -151,6 +151,7 @@ DATA: 'data';
 NETWORK: 'network';
 PRIOR: 'prior';
 GUIDE: 'guide';
+GUIDEPARAMETERS : 'guide_parameters';
 PARAMETERS: 'parameters';
 QUANTITIES: 'quantities';
 TRANSFORMED: 'transformed';
@@ -575,6 +576,11 @@ guideBlock
     : GUIDE '{' variableDeclsOpt statementsOpt '}'
     ;
 
+guideParametersBlock
+    : GUIDEPARAMETERS '{' variableDeclsOpt '}'
+    ;
+
+
 transformedDataBlock
     : TRANSFORMED DATA '{' variableDeclsOpt statementsOpt '}'
     ;
@@ -603,6 +609,7 @@ program
         transformedParametersBlock?
         networkBlock?
         priorBlock?
+        guideParametersBlock?
         guideBlock?
         modelBlock?
         generatedQuantitiesBlock?

--- a/deepppl/tests/good/coin_guide.stan
+++ b/deepppl/tests/good/coin_guide.stan
@@ -22,9 +22,14 @@ parameters {
 }
 
 
-guide {
+guide_parameters
+{
   real<lower=0>  alpha_q;
   real<lower=0>  beta_q;
+}
+
+guide {
+
   alpha_q = 15.0;
   beta_q = 15.0;
   theta ~ beta(alpha_q, beta_q);

--- a/deepppl/tests/good/mlp.stan
+++ b/deepppl/tests/good/mlp.stan
@@ -38,7 +38,8 @@ prior
     mlp.l2.bias ~  Normal(0, 1);
 }
 
-guide{
+guide_parameters
+{
     real l1wloc;
     real l1wscale;
     real l1bloc;
@@ -47,7 +48,9 @@ guide{
     real l2wscale;
     real l2bloc;
     real l2bscale;
+}
 
+guide {
     l1wloc = randn(0,1);
     l1wscale = exp(randn());
     mlp.l1.weight ~  Normal(l1wloc, l1wscale);

--- a/deepppl/tests/good/vae.stan
+++ b/deepppl/tests/good/vae.stan
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+data {
+    int x;
+}
+
+
+
+parameters{
+    int latent;
+}
+
+network {
+    Decoder decoder;
+    Encoder encoder;
+}
+
+guide {
+    real encoded[2];
+    real mu;
+    real sigma;
+    encoded = encoder(x);
+    mu = encoded[1];
+    sigma = encoded[2];
+    latent ~ normal(mu, sigma);
+}
+
+model {
+    int loc_img;
+    latent ~ Normal(0, 1);
+    loc_img = decoder(latent);
+    x ~ Bernoulli(loc_img)
+}
+
+

--- a/deepppl/tests/good/vae.stan
+++ b/deepppl/tests/good/vae.stan
@@ -21,7 +21,7 @@ data {
 
 
 
-parameters{
+parameters {
     int latent;
 }
 

--- a/deepppl/tests/target_py/vae.py
+++ b/deepppl/tests/target_py/vae.py
@@ -1,0 +1,19 @@
+import torch
+from torch import tensor
+import pyro
+import pyro.distributions as dist
+
+
+def guide_(x):
+    pyro.module("encoder", encoder)
+    encoded = encoder(x)
+    mu = encoded[tensor(1) - 1]
+    sigma = encoded[tensor(2) - 1]
+    latent = pyro.sample('latent', dist.Normal(mu, sigma))
+
+
+def model(x):
+    pyro.module("decoder", decoder)
+    latent = pyro.sample('latent', dist.Normal(tensor(0), tensor(1)))
+    loc_img = decoder(latent)
+    pyro.sample('x', dist.Bernoulli(loc_img), obs=x)

--- a/deepppl/tests/test_irl.py
+++ b/deepppl/tests/test_irl.py
@@ -73,6 +73,7 @@ def test_mlp():
     target_file = r'deepppl/tests/target_py/mlp.py'
     normalize_and_compare(filename, target_file)
 
+@pytest.mark.xfail(strict=True)
 def test_vae():
     filename = r'deepppl/tests/good/vae.stan'
     target_file = r'deepppl/tests/target_py/vae.py'

--- a/deepppl/tests/test_irl.py
+++ b/deepppl/tests/test_irl.py
@@ -72,3 +72,8 @@ def test_mlp():
     filename = r'deepppl/tests/good/mlp.stan'
     target_file = r'deepppl/tests/target_py/mlp.py'
     normalize_and_compare(filename, target_file)
+
+def test_vae():
+    filename = r'deepppl/tests/good/vae.stan'
+    target_file = r'deepppl/tests/target_py/mlp.py'
+    normalize_and_compare(filename, target_file)

--- a/deepppl/tests/test_irl.py
+++ b/deepppl/tests/test_irl.py
@@ -75,5 +75,5 @@ def test_mlp():
 
 def test_vae():
     filename = r'deepppl/tests/good/vae.stan'
-    target_file = r'deepppl/tests/target_py/mlp.py'
+    target_file = r'deepppl/tests/target_py/vae.py'
     normalize_and_compare(filename, target_file)

--- a/deepppl/translation/ir.py
+++ b/deepppl/translation/ir.py
@@ -47,7 +47,9 @@ class Program(IR):
     
     def blocks(self):
         ## impose an evaluation order
-        blockNames = ['data', 'parameters', 'guide', 'prior', 'model']
+        blockNames = [
+                        'data', 'parameters', 'guideparameters', \
+                        'guide', 'prior', 'model']
         for name in blockNames:
             block = getattr(self, name, None)
             if block is not None:
@@ -82,6 +84,9 @@ class ProgramBlocks(IR):
     def is_guide(self):
         return False
 
+    def is_guide_parameters(self):
+        return False
+
     def is_prior(self):
         return False
 
@@ -94,6 +99,10 @@ class Model(ProgramBlocks):
 
 class Guide(ProgramBlocks):
     def is_guide(self):
+        return True
+
+class GuideParameters(ProgramBlocks):
+    def is_guide_parameters(self):
         return True
 
 class Prior(ProgramBlocks):
@@ -239,6 +248,9 @@ class Expression(Statements):
     def is_guide_var(self):
         return (x.is_guide_var() for x in self.children)
 
+    def is_guide_parameters(self):
+        return (x.is_guide_parameters_var() for x in self.children)
+
     def is_prior_var(self):
         return (x.is_prior_var() for x in self.children)
 
@@ -317,6 +329,9 @@ class Subscript(Expression):
     def is_guide_var(self):
         return self.id.is_guide_var()
 
+    def is_guide_parameters_var(self):
+        return self.id.is_guide_parameters_var()
+
     def is_prior_var(self):
         return self.id.is_prior_var()
 
@@ -359,6 +374,9 @@ class Variable(Expression):
 
     def is_guide_var(self):
         return self.block_name == Guide.blockName()
+
+    def is_guide_parameters_var(self):
+        return self.block_name == GuideParameters.blockName()
 
     def is_prior_var(self):
         return self.block_name == Prior.blockName()

--- a/deepppl/translation/ir2python.py
+++ b/deepppl/translation/ir2python.py
@@ -112,7 +112,7 @@ class VariableAnnotationsVisitor(IRVisitor):
     def visitVariable(self, var):
         name = var.id
         if name not in self.ctx:
-            assert False, "Use of undeclared variable:{name}".format(name)
+            assert False, "Use of undeclared variable:{}".format(name)
         var.block_name = self.ctx[name].blockName()
         return var
 

--- a/deepppl/translation/stan2ir.py
+++ b/deepppl/translation/stan2ir.py
@@ -319,13 +319,18 @@ class StanToIR(stanListener):
                 ir.set_data()
         ctx.ir = Data(body = body)
 
-    def exitParametersBlock(self, ctx):
+    def code_block(self, ctx, cls):
         body = gatherChildrenIRList(ctx)
-        ctx.ir = Parameters(body = body)
+        ctx.ir = cls(body = body)
+
+    def exitParametersBlock(self, ctx):
+        self.code_block(ctx, Parameters)
 
     def exitGuideBlock(self, ctx):
-        body = gatherChildrenIRList(ctx)
-        ctx.ir = Guide(body = body)
+        self.code_block(ctx, Guide)
+
+    def exitGuideParametersBlock(self, ctx):
+        self.code_block(ctx, GuideParameters)
 
     def exitPriorBlock(self, ctx):
         # TODO: unify gatherChildrenIRList: check for StatemetnsOpt


### PR DESCRIPTION
The `guide` section has the same interface as the `model` section and behaves in a related way.
In order to match this similarity, a `guide_parameters` section must be introduced.
Variables declared in that section will be added to `pyro`'s `parameters` store.

In order to finish the _variational autoencoder` example, #12 must be fixed.