### PR TITLE
PyTorch modules

### DIFF
--- a/deepppl/examples/coin-guided.ipynb
+++ b/deepppl/examples/coin-guided.ipynb
@@ -71,9 +71,14 @@
     "}\n",
     "\n",
     "\n",
-    "guide {\n",
+    "guide_parameters\n",
+    "{\n",
     "  real<lower=0>  alpha_q;\n",
     "  real<lower=0>  beta_q;\n",
+    "}\n",
+    "\n",
+    "guide {\n",
+    "\n",
     "  alpha_q = 15.0;\n",
     "  beta_q = 15.0;\n",
     "  theta ~ beta(alpha_q, beta_q);\n",
@@ -166,7 +171,7 @@
     {
      "data": {
       "text/plain": [
-       "(12.50866985321045, 17.216354370117188)"
+       "(12.530339241027832, 17.1934814453125)"
       ]
      },
      "execution_count": 11,
@@ -186,7 +191,7 @@
     {
      "data": {
       "text/plain": [
-       "0.4208127724045346"
+       "0.42155883569793523"
       ]
      },
      "execution_count": 12,
@@ -207,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/deepppl/parser/stan.g4
+++ b/deepppl/parser/stan.g4
@@ -157,6 +157,9 @@ QUANTITIES: 'quantities';
 TRANSFORMED: 'transformed';
 GENERATED: 'generated';
 
+/* Network keywords */
+WITHPARAMS : 'with parameters';
+
 /* Reserved Names from Stan Implementation */
 VAR: 'var';
 FVAR: 'fvar';
@@ -336,15 +339,28 @@ variableDecl
     ;
 
 netVariableDecl
-    : IDENTIFIER IDENTIFIER ';'
+    : netClass netName ';'
+    | netClass netName WITHPARAMS ':' netParamDecl+
     ;
 
-netLValue
-    : netName ('.' IDENTIFIER)*
+netClass
+    : IDENTIFIER
     ;
 
 netName
     : IDENTIFIER
+    ;
+
+netParamDecl
+    : netParam ';'
+    ;
+
+netParam
+    :  IDENTIFIER ('.' netParam)*
+    ;
+
+netLValue
+    : netName '.' netParam
     ;
 
 arrayDim

--- a/deepppl/tests/good/mlp.stan
+++ b/deepppl/tests/good/mlp.stan
@@ -22,12 +22,11 @@ data {
 }
 
 network {
-    MLP mlp;
-    // MLP mlp with parameters:
-    //   l1.weight;
-    //   l1.bias;
-    //   l2.weight;
-    //   l2.bias;
+    MLP mlp with parameters:
+        l1.weight;
+        l1.bias;
+        l2.weight;
+        l2.bias;
 }
 
 prior

--- a/deepppl/tests/good/vae.stan
+++ b/deepppl/tests/good/vae.stan
@@ -44,7 +44,7 @@ model {
     int loc_img;
     latent ~ Normal(0, 1);
     loc_img = decoder(latent);
-    x ~ Bernoulli(loc_img)
+    x ~ Bernoulli(loc_img);
 }
 
 

--- a/deepppl/tests/test_irl.py
+++ b/deepppl/tests/test_irl.py
@@ -73,7 +73,7 @@ def test_mlp():
     target_file = r'deepppl/tests/target_py/mlp.py'
     normalize_and_compare(filename, target_file)
 
-@pytest.mark.xfail(strict=True)
+
 def test_vae():
     filename = r'deepppl/tests/good/vae.stan'
     target_file = r'deepppl/tests/target_py/vae.py'

--- a/deepppl/translation/ir.py
+++ b/deepppl/translation/ir.py
@@ -381,6 +381,13 @@ class Variable(Expression):
     def is_prior_var(self):
         return self.block_name == Prior.blockName()
 
+class NetDeclaration(IR):
+    def __init__(self, name = None, cls = None, params = []):
+        super(NetDeclaration, self).__init__()
+        self.name = name
+        self.net_cls = cls
+        self.params = params 
+
 class NetVariable(Expression):
     def __init__(self, name = None, ids =  []):
         super(NetVariable, self).__init__()

--- a/deepppl/translation/ir.py
+++ b/deepppl/translation/ir.py
@@ -102,6 +102,10 @@ class Model(ProgramBlocks):
         return True
 
 class Guide(ProgramBlocks):
+    def __init__(self, body = []):
+        super(Guide, self).__init__(body = body)
+        self._nets = []
+
     def is_guide(self):
         return True
 
@@ -125,6 +129,10 @@ class NetworksBlock(ProgramBlocks):
         return True
 
 class Prior(ProgramBlocks):
+    def __init__(self, body = []):
+        super(Prior, self).__init__(body = body)
+        self._nets = []
+
     def is_prior(self):
         return True
 

--- a/deepppl/translation/ir.py
+++ b/deepppl/translation/ir.py
@@ -48,7 +48,8 @@ class Program(IR):
     def blocks(self):
         ## impose an evaluation order
         blockNames = [
-                        'data', 'parameters', 'guideparameters', \
+                        'data', 'parameters', 'networksblock',  \
+                        'guideparameters', \
                         'guide', 'prior', 'model']
         for name in blockNames:
             block = getattr(self, name, None)
@@ -84,6 +85,9 @@ class ProgramBlocks(IR):
     def is_guide(self):
         return False
 
+    def is_networks(self):
+        return True
+
     def is_guide_parameters(self):
         return False
 
@@ -103,6 +107,21 @@ class Guide(ProgramBlocks):
 
 class GuideParameters(ProgramBlocks):
     def is_guide_parameters(self):
+        return True
+
+class NetworksBlock(ProgramBlocks):
+    def __init__(self, decls = None):
+        super(NetworksBlock, self).__init__(body = decls)
+
+    @property
+    def decls(self):
+        return self.body
+
+    @decls.setter
+    def decls(self, decls):
+        self.body = decls
+
+    def is_networks(self):
         return True
 
 class Prior(ProgramBlocks):
@@ -386,7 +405,7 @@ class NetDeclaration(IR):
         super(NetDeclaration, self).__init__()
         self.name = name
         self.net_cls = cls
-        self.params = params 
+        self.params = params
 
 class NetVariable(Expression):
     def __init__(self, name = None, ids =  []):

--- a/deepppl/translation/ir.py
+++ b/deepppl/translation/ir.py
@@ -98,6 +98,10 @@ class ProgramBlocks(IR):
         return False
 
 class Model(ProgramBlocks):
+    def __init__(self, body = []):
+        super(Model, self).__init__(body = body)
+        self._blackBoxNets = set()
+        
     def is_model(self):
         return True
 
@@ -105,6 +109,7 @@ class Guide(ProgramBlocks):
     def __init__(self, body = []):
         super(Guide, self).__init__(body = body)
         self._nets = []
+        self._blackBoxNets = set()
 
     def is_guide(self):
         return True
@@ -132,6 +137,7 @@ class Prior(ProgramBlocks):
     def __init__(self, body = []):
         super(Prior, self).__init__(body = body)
         self._nets = []
+        self._blackBoxNets = set()
 
     def is_prior(self):
         return True

--- a/deepppl/translation/ir2python.py
+++ b/deepppl/translation/ir2python.py
@@ -159,7 +159,9 @@ class NetworkVisitor(IRVisitor):
 
     def visitPrior(self, prior):
         self._currdict = self._priors
+        nets = [net for net in self._currdict if self._currdict[net]]
         answer = self.defaultVisit(prior)
+        answer._nets = nets
         for net in self._currdict:
             params = self._currdict[net]
             assert not params, "The following parameters were note given a prior:{}".format(params)
@@ -168,7 +170,9 @@ class NetworkVisitor(IRVisitor):
 
     def visitGuide(self, guide):
         self._currdict = self._guides
+        nets = [net for net in self._currdict if self._currdict[net]]
         answer = self.defaultVisit(guide)
+        answer._nets = nets
         for net in self._currdict:
             params = self._currdict[net]
             assert not params, "The following parameters were note given a guide:{}".format(params)
@@ -515,7 +519,9 @@ class Ir2PythonVisitor(IRVisitor):
         return body
 
     def visitPrior(self, prior):
-        name = prior.body[0].target.name
+        is_net = len(prior._nets) > 0
+        assert is_net and len(prior._nets) == 1
+        name = prior._nets[0] if is_net else  ''
         name_prior = 'prior_' + name ## XXX
         ## TODO: only one nn is suported in here.
         body = self.liftBody(prior, name, name_prior)
@@ -525,11 +531,9 @@ class Ir2PythonVisitor(IRVisitor):
 
 
     def visitGuide(self, guide):
-        ## Hack!!! XXX
-        ## a guide needs to know if it's working with a nn module
-        ## as it should create the guide's dictionary and lift it
-        is_net = guide.body[-1].target.is_net_var()
-        name = guide.body[-1].target.name if is_net else  ''
+        is_net = len(guide._nets) > 0
+        assert is_net and len(guide._nets) == 1
+        name = guide._nets[0] if is_net else  ''
         ## TODO: only one nn is suported in here.
         name_guide = 'guide_' + name ## XXX
 

--- a/deepppl/translation/stan2ir.py
+++ b/deepppl/translation/stan2ir.py
@@ -205,10 +205,27 @@ class StanToIR(stanListener):
         else:
             assert False
 
+    def exitNetParam(self, ctx):
+        ids = [ctx.IDENTIFIER().getText()]
+        if ctx.netParam():
+            ir = ctx.netParam()[0].ir
+            ids.extend(ir)
+        ctx.ir = ids
+
+    def exitNetVariableDecl(self, ctx):
+        netCls = ctx.netClass()
+        name = ctx.netName()
+        parameters = [x.ir for x in ctx.netParamDecl()]
+        ctx.ir = NetDeclaration(name = name, cls = netCls, \
+                                params = parameters)
+
+    def exitNetParamDecl(self, ctx):
+        ctx.ir = ctx.netParam().ir
+        
 
     def exitNetLValue(self, ctx):
         name = ctx.netName().getText()
-        ids = [x.getText() for x in ctx.IDENTIFIER()]
+        ids = ctx.netParam().ir
         ctx.ir = NetVariable(name = name, ids = ids)
 
     def exitSamplingStmt(self, ctx):

--- a/deepppl/translation/stan2ir.py
+++ b/deepppl/translation/stan2ir.py
@@ -212,9 +212,20 @@ class StanToIR(stanListener):
             ids.extend(ir)
         ctx.ir = ids
 
+    def exitNetworkBlock(self, ctx):
+        ops = ctx.netVariableDeclsOpt()
+        decls = [x.ir for x in ops.netVariableDecl()]
+        nets = NetworksBlock(decls = decls)
+        ctx.ir = nets
+
+    def exitNetClass(self, ctx):
+        ctx.ir = ctx.getText()
+
+    exitNetName = exitNetClass
+
     def exitNetVariableDecl(self, ctx):
-        netCls = ctx.netClass()
-        name = ctx.netName()
+        netCls = ctx.netClass().ir
+        name = ctx.netName().ir
         parameters = [x.ir for x in ctx.netParamDecl()]
         ctx.ir = NetDeclaration(name = name, cls = netCls, \
                                 params = parameters)


### PR DESCRIPTION
Fix #12 
There are two possible uses for PyTorch modules:
1. They can be used as black box function.
1. Or uncertainty can be added to the parameters.

When a network is declared with their parameters using the keywords `with parameters:`, that implies that all of these parameters must have both a guide and a prior. Additionally, this network module must be lift using the `random_module` command from `pyro`.
On the other hand, when the network is declared without parameters, the network module must be register to `pyro` using the `module` command.