### PR TITLE
Shapes

### DIFF
--- a/deepppl/parser/stan.g4
+++ b/deepppl/parser/stan.g4
@@ -85,7 +85,6 @@ Symbol
     : '~'
     | '@'
     | '#'
-    | '$'
     | '%'
     | '^'
     | '&'
@@ -386,6 +385,11 @@ variable
     : IDENTIFIER
     ;
 
+variableProperty
+    : variable '$' IDENTIFIER
+    | netLValue '$' IDENTIFIER
+    ;
+
 /** Vector, matrix and array expressions (section 4.2) */
 
 vectorExpr
@@ -399,6 +403,8 @@ arrayExpr
 atom
     : constant
     | variable
+    | netLValue
+    | variableProperty
     | vectorExpr
     | arrayExpr
     | atom '[' indexExpression ']'

--- a/deepppl/tests/good/lstm.stan
+++ b/deepppl/tests/good/lstm.stan
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+data {
+    int n_characters;
+    int input[n_characters];
+    int target[n_characters];
+}
+
+network {
+    RNN rnn with parameters:
+        encoder.weight;
+        gru.weight_ih_l0;
+        gru.weight_hh_l0;
+        gru.bias_ih_l0;
+        gru.bias_hh_l0;
+        decoder.weight;
+        decoder.bias;
+}
+
+prior
+{
+    rnn.encoder.weight ~  Normal(0, 1);
+    rnn.gru.weight_ih_l0 ~ Normal(0, 1);
+    rnn.gru.weight_hh_l0 ~ Normal(0, 1);
+    rnn.gru.bias_ih_l0 ~  Normal(0, 1);
+    rnn.gru.bias_hh_l0 ~  Normal(0, 1);
+    rnn.decoder.weight ~  Normal(0, 1);
+    rnn.decoder.bias ~  Normal(0, 1);
+}
+
+guide_parameters
+{
+    real ewl;
+    real ews;
+    real gw1l;
+    real gw1s;
+    real gw2l;
+    real gw2s;
+    real gb1l;
+    real gb1s;
+    real gb2l;
+    real gb2s;
+    real dwl;
+    real dws;
+    real dbl;
+    real dbs;
+
+}
+
+guide {
+    ewl = randn();
+    ews = exp(randn());
+    rnn.encoder.weight ~  Normal(ewl, ews);
+    gw1l = randn();
+    gw1s = exp(randn());
+    rnn.gru.weight_ih_l0 ~ Normal(gw1l, gw1s);
+    gw2l = randn();
+    gw2s = exp(randn());
+    rnn.gru.weight_hh_l0 ~ Normal(gw2l, gw2s);
+    gb1l = randn();
+    gb1s = exp(randn());
+    rnn.gru.bias_ih_l0 ~  Normal(gb1l, gb1s);
+    gb2l = randn();
+    gb2s = exp(randn());
+    rnn.gru.bias_hh_l0 ~  Normal(gb2l, gb2s);
+    dwl = randn();
+    dws = exp(randn());
+    rnn.decoder.weight ~  Normal(dwl, dws);
+    dbl = randn();
+    dbs = exp(randn());
+    rnn.decoder.bias ~  Normal(dbl, dbs);
+}
+
+model {
+    int logits[n_characters];
+    logits = rnn(input);
+    target ~ Categorical(logits);
+}
+
+

--- a/deepppl/tests/good/lstm.stan
+++ b/deepppl/tests/good/lstm.stan
@@ -34,55 +34,55 @@ network {
 
 prior
 {
-    rnn.encoder.weight ~  Normal(0, 1);
-    rnn.gru.weight_ih_l0 ~ Normal(0, 1);
-    rnn.gru.weight_hh_l0 ~ Normal(0, 1);
-    rnn.gru.bias_ih_l0 ~  Normal(0, 1);
-    rnn.gru.bias_hh_l0 ~  Normal(0, 1);
-    rnn.decoder.weight ~  Normal(0, 1);
-    rnn.decoder.bias ~  Normal(0, 1);
+    rnn.encoder.weight ~  Normal(zeros(rnn.encoder.weight$shape), ones(rnn.encoder.weight$shape));
+    rnn.gru.weight_ih_l0 ~ Normal(zeros(rnn.gru.weight_ih_l0$shape), ones(rnn.gru.weight_ih_l0$shape));
+    rnn.gru.weight_hh_l0 ~ Normal(zeros(rnn.gru.weight_hh_l0$shape), ones(rnn.gru.weight_hh_l0$shape));
+    rnn.gru.bias_ih_l0 ~  Normal(zeros(rnn.gru.bias_ih_l0$shape), ones(rnn.gru.bias_ih_l0$shape));
+    rnn.gru.bias_hh_l0 ~  Normal(zeros(rnn.gru.bias_hh_l0$shape), ones(rnn.gru.bias_hh_l0$shape));
+    rnn.decoder.weight ~  Normal(zeros(rnn.decoder.weight$shape), ones(rnn.decoder.weight$shape));
+    rnn.decoder.bias ~  Normal(zeros(rnn.decoder.bias$shape), ones(rnn.decoder.bias$shape));
 }
 
 guide_parameters
 {
-    real ewl;
-    real ews;
-    real gw1l;
-    real gw1s;
-    real gw2l;
-    real gw2s;
-    real gb1l;
-    real gb1s;
-    real gb2l;
-    real gb2s;
-    real dwl;
-    real dws;
-    real dbl;
-    real dbs;
+    real ewl[rnn.encoder.weight$shape];
+    real ews[rnn.encoder.weight$shape];
+    real gw1l[rnn.gru.weight_ih_l0$shape];
+    real gw1s[rnn.gru.weight_ih_l0$shape];
+    real gw2l[rnn.gru.weight_hh_l0$shape];
+    real gw2s[rnn.gru.weight_hh_l0$shape];
+    real gb1l[rnn.gru.bias_ih_l0$shape];
+    real gb1s[rnn.gru.bias_ih_l0$shape];
+    real gb2l[rnn.gru.bias_hh_l0$shape];
+    real gb2s[rnn.gru.bias_hh_l0$shape];
+    real dwl[rnn.decoder.weight$shape];
+    real dws[rnn.decoder.weight$shape];
+    real dbl[rnn.decoder.bias$shape];
+    real dbs[rnn.decoder.bias$shape];
 
 }
 
 guide {
-    ewl = randn();
-    ews = exp(randn());
-    rnn.encoder.weight ~  Normal(ewl, ews);
-    gw1l = randn();
-    gw1s = exp(randn());
+    ewl = randn(ewl$shape);
+    ews = exp(randn(ews$shape));
+    rnn.encoder.weight ~  LogNormal(ewl, ews);
+    gw1l = randn(gw1l$shape);
+    gw1s = exp(randn(gw1s$shape));
     rnn.gru.weight_ih_l0 ~ Normal(gw1l, gw1s);
-    gw2l = randn();
-    gw2s = exp(randn());
+    gw2l = randn(gw2l$shape);
+    gw2s = exp(randn(gw2s$shape));
     rnn.gru.weight_hh_l0 ~ Normal(gw2l, gw2s);
-    gb1l = randn();
-    gb1s = exp(randn());
+    gb1l = randn(gb1l$shape);
+    gb1s = exp(randn(gb1s$shape));
     rnn.gru.bias_ih_l0 ~  Normal(gb1l, gb1s);
-    gb2l = randn();
-    gb2s = exp(randn());
+    gb2l = randn(gb2l$shape);
+    gb2s = exp(randn(gb2s$shape));
     rnn.gru.bias_hh_l0 ~  Normal(gb2l, gb2s);
-    dwl = randn();
-    dws = exp(randn());
+    dwl = randn(dwl$shape);
+    dws = exp(randn(dws$shape));
     rnn.decoder.weight ~  Normal(dwl, dws);
-    dbl = randn();
-    dbs = exp(randn());
+    dbl = randn(dbl$shape);
+    dbs = exp(randn(dbs$shape));
     rnn.decoder.bias ~  Normal(dbl, dbs);
 }
 

--- a/deepppl/tests/good/mlp.stan
+++ b/deepppl/tests/good/mlp.stan
@@ -31,36 +31,36 @@ network {
 
 prior
 {
-    mlp.l1.weight ~  Normal(0, 1);
-    mlp.l1.bias ~ Normal(0, 1);
-    mlp.l2.weight ~ Normal(0, 1);
-    mlp.l2.bias ~  Normal(0, 1);
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
 }
 
 guide_parameters
 {
-    real l1wloc;
-    real l1wscale;
-    real l1bloc;
-    real l1bscale;
-    real l2wloc;
-    real l2wscale;
-    real l2bloc;
-    real l2bscale;
+    real l1wloc[mlp.l1.weight$shape];
+    real l1wscale[mlp.l1.weight$shape];
+    real l1bloc[mlp.l1.bias$shape];
+    real l1bscale[mlp.l1.bias$shape];
+    real l2wloc[mlp.l2.weight$shape];
+    real l2wscale[mlp.l2.weight$shape];
+    real l2bloc[mlp.l2.bias$shape];
+    real l2bscale[mlp.l2.bias$shape];
 }
 
 guide {
-    l1wloc = randn(0,1);
-    l1wscale = exp(randn());
+    l1wloc = randn(l1wloc$shape);
+    l1wscale = exp(randn(l1wscale$shape));
     mlp.l1.weight ~  Normal(l1wloc, l1wscale);
-    l1bloc = randn(0,1);
-    l1bscale = exp(randn());
+    l1bloc = randn(l1bloc$shape);
+    l1bscale = exp(randn(l1bscale$shape));
     mlp.l1.bias ~ Normal(l1bloc, l1bscale);
-    l2wloc = randn(0,1);
-    l2wscale = exp(randn());
+    l2wloc = randn(l2wloc$shape);
+    l2wscale = exp(randn(l2wscale$shape));
     mlp.l2.weight ~ Normal(l2wloc, l2wscale);
-    l2bloc = randn();
-    l2bscale = exp(randn());
+    l2bloc = randn(l2bloc$shape);
+    l2bscale = exp(randn(l2bscale$shape));
     mlp.l2.bias ~ Normal(l2bloc, l2bscale);
 }
 

--- a/deepppl/tests/target_py/coin.py
+++ b/deepppl/tests/target_py/coin.py
@@ -5,6 +5,8 @@ import pyro.distributions as dist
 
 
 def model(x):
+    ___shape = {}
+    ___shape['x'] = tensor(10)
     theta = pyro.sample('theta', dist.Uniform(tensor(0.0), tensor(1.0)))
     for i in range(tensor(1), tensor(10) + 1):
         pyro.sample('x' + '{}'.format(i - 1), dist.Bernoulli(theta), obs=x[i - 1])

--- a/deepppl/tests/target_py/coin_guide.py
+++ b/deepppl/tests/target_py/coin_guide.py
@@ -5,13 +5,16 @@ import pyro.distributions as dist
 
 
 def guide_(x):
+    ___shape = {}
+    ___shape['x'] = tensor(10)
     alpha_q = pyro.param('alpha_q', tensor(15.0))
     beta_q = pyro.param('beta_q', tensor(15.0))
     theta = pyro.sample('theta', dist.Beta(alpha_q, beta_q))
 
 
 def model(x):
+    ___shape = {}
+    ___shape['x'] = tensor(10)
     theta = pyro.sample('theta', dist.Beta(tensor(10.0), tensor(10.0)))
     for i in range(tensor(1), tensor(10) + 1):
-        pyro.sample('x' + '{}'.format(i - 1), dist.Bernoulli(theta), obs=x[
-            i - 1])
+        pyro.sample('x' + '{}'.format(i - 1), dist.Bernoulli(theta), obs=x[i-1])

--- a/deepppl/tests/target_py/coin_vectorized.py
+++ b/deepppl/tests/target_py/coin_vectorized.py
@@ -5,5 +5,7 @@ import pyro.distributions as dist
 
 
 def model(x):
+    ___shape = {}
+    ___shape['x'] = tensor(10)
     theta = pyro.sample('theta', dist.Uniform(tensor(0.0), tensor(1.0)))
     pyro.sample('x', dist.Bernoulli(theta), obs=x)

--- a/deepppl/tests/target_py/lstm.py
+++ b/deepppl/tests/target_py/lstm.py
@@ -1,0 +1,50 @@
+import torch
+from torch import tensor
+import pyro
+import pyro.distributions as dist
+
+
+def guide_rnn(input, n_characters, target):
+    guide_rnn = {}
+    ewl = pyro.param('ewl', randn())
+    ews = pyro.param('ews', exp(randn()))
+    guide_rnn['encoder.weight'] = dist.Normal(ewl, ews)
+    gw1l = pyro.param('gw1l', randn())
+    gw1s = pyro.param('gw1s', exp(randn()))
+    guide_rnn['gru.weight_ih_l0'] = dist.Normal(gw1l, gw1s)
+    gw2l = pyro.param('gw2l', randn())
+    gw2s = pyro.param('gw2s', exp(randn()))
+    guide_rnn['gru.weight_hh_l0'] = dist.Normal(gw2l, gw2s)
+    gb1l = pyro.param('gb1l', randn())
+    gb1s = pyro.param('gb1s', exp(randn()))
+    guide_rnn['gru.bias_ih_l0'] = dist.Normal(gb1l, gb1s)
+    gb2l = pyro.param('gb2l', randn())
+    gb2s = pyro.param('gb2s', exp(randn()))
+    guide_rnn['gru.bias_hh_l0'] = dist.Normal(gb2l, gb2s)
+    dwl = pyro.param('dwl', randn())
+    dws = pyro.param('dws', exp(randn()))
+    guide_rnn['decoder.weight'] = dist.Normal(dwl, dws)
+    dbl = pyro.param('dbl', randn())
+    dbs = pyro.param('dbs', exp(randn()))
+    guide_rnn['decoder.bias'] = dist.Normal(dbl, dbs)
+    lifted_rnn = pyro.random_module('rnn', rnn, guide_rnn)
+    return lifted_rnn()
+
+
+def prior_rnn():
+    prior_rnn = {}
+    prior_rnn['encoder.weight'] = dist.Normal(tensor(0), tensor(1))
+    prior_rnn['gru.weight_ih_l0'] = dist.Normal(tensor(0), tensor(1))
+    prior_rnn['gru.weight_hh_l0'] = dist.Normal(tensor(0), tensor(1))
+    prior_rnn['gru.bias_ih_l0'] = dist.Normal(tensor(0), tensor(1))
+    prior_rnn['gru.bias_hh_l0'] = dist.Normal(tensor(0), tensor(1))
+    prior_rnn['decoder.weight'] = dist.Normal(tensor(0), tensor(1))
+    prior_rnn['decoder.bias'] = dist.Normal(tensor(0), tensor(1))
+    lifted_rnn = pyro.random_module('rnn', rnn, prior_rnn)
+    return lifted_rnn()
+
+
+def model(input, n_characters, target):
+    rnn = prior_rnn()
+    logits = rnn(input)
+    pyro.sample('target', dist.Categorical(logits), obs=target)

--- a/deepppl/tests/target_py/lstm.py
+++ b/deepppl/tests/target_py/lstm.py
@@ -48,7 +48,7 @@ def guide_rnn(input, n_characters, target):
     return lifted_rnn()
 
 
-def prior_rnn():
+def prior_rnn(input, n_characters, target):
     ___shape = {}
     ___shape['input'] = n_characters
     ___shape['target'] = n_characters
@@ -68,7 +68,7 @@ def model(input, n_characters, target):
     ___shape = {}
     ___shape['input'] = n_characters
     ___shape['target'] = n_characters
-    rnn = prior_rnn()
+    rnn = prior_rnn(input, n_characters, target)
     ___shape['logits'] = n_characters
     logits = rnn(input)
     pyro.sample('target', dist.Categorical(logits), obs=target)

--- a/deepppl/tests/target_py/lstm.py
+++ b/deepppl/tests/target_py/lstm.py
@@ -5,46 +5,70 @@ import pyro.distributions as dist
 
 
 def guide_rnn(input, n_characters, target):
+    ___shape = {}
+    ___shape['input'] = n_characters
+    ___shape['target'] = n_characters
+    ___shape['ewl'] = rnn.encoder.weight.shape()
+    ___shape['ews'] = rnn.encoder.weight.shape()
+    ___shape['gw1l'] = rnn.gru.weight_ih_l0.shape()
+    ___shape['gw1s'] = rnn.gru.weight_ih_l0.shape()
+    ___shape['gw2l'] = rnn.gru.weight_hh_l0.shape()
+    ___shape['gw2s'] = rnn.gru.weight_hh_l0.shape()
+    ___shape['gb1l'] = rnn.gru.bias_ih_l0.shape()
+    ___shape['gb1s'] = rnn.gru.bias_ih_l0.shape()
+    ___shape['gb2l'] = rnn.gru.bias_hh_l0.shape()
+    ___shape['gb2s'] = rnn.gru.bias_hh_l0.shape()
+    ___shape['dwl'] = rnn.decoder.weight.shape()
+    ___shape['dws'] = rnn.decoder.weight.shape()
+    ___shape['dbl'] = rnn.decoder.bias.shape()
+    ___shape['dbs'] = rnn.decoder.bias.shape()
     guide_rnn = {}
-    ewl = pyro.param('ewl', randn())
-    ews = pyro.param('ews', exp(randn()))
-    guide_rnn['encoder.weight'] = dist.Normal(ewl, ews)
-    gw1l = pyro.param('gw1l', randn())
-    gw1s = pyro.param('gw1s', exp(randn()))
+    ewl = pyro.param('ewl', randn(___shape['ewl']))
+    ews = pyro.param('ews', exp(randn(___shape['ews'])))
+    guide_rnn['encoder.weight'] = dist.LogNormal(ewl, ews)
+    gw1l = pyro.param('gw1l', randn(___shape['gw1l']))
+    gw1s = pyro.param('gw1s', exp(randn(___shape['gw1s'])))
     guide_rnn['gru.weight_ih_l0'] = dist.Normal(gw1l, gw1s)
-    gw2l = pyro.param('gw2l', randn())
-    gw2s = pyro.param('gw2s', exp(randn()))
+    gw2l = pyro.param('gw2l', randn(___shape['gw2l']))
+    gw2s = pyro.param('gw2s', exp(randn(___shape['gw2s'])))
     guide_rnn['gru.weight_hh_l0'] = dist.Normal(gw2l, gw2s)
-    gb1l = pyro.param('gb1l', randn())
-    gb1s = pyro.param('gb1s', exp(randn()))
+    gb1l = pyro.param('gb1l', randn(___shape['gb1l']))
+    gb1s = pyro.param('gb1s', exp(randn(___shape['gb1s'])))
     guide_rnn['gru.bias_ih_l0'] = dist.Normal(gb1l, gb1s)
-    gb2l = pyro.param('gb2l', randn())
-    gb2s = pyro.param('gb2s', exp(randn()))
+    gb2l = pyro.param('gb2l', randn(___shape['gb2l']))
+    gb2s = pyro.param('gb2s', exp(randn(___shape['gb2s'])))
     guide_rnn['gru.bias_hh_l0'] = dist.Normal(gb2l, gb2s)
-    dwl = pyro.param('dwl', randn())
-    dws = pyro.param('dws', exp(randn()))
+    dwl = pyro.param('dwl', randn(___shape['dwl']))
+    dws = pyro.param('dws', exp(randn(___shape['dws'])))
     guide_rnn['decoder.weight'] = dist.Normal(dwl, dws)
-    dbl = pyro.param('dbl', randn())
-    dbs = pyro.param('dbs', exp(randn()))
+    dbl = pyro.param('dbl', randn(___shape['dbl']))
+    dbs = pyro.param('dbs', exp(randn(___shape['dbs'])))
     guide_rnn['decoder.bias'] = dist.Normal(dbl, dbs)
     lifted_rnn = pyro.random_module('rnn', rnn, guide_rnn)
     return lifted_rnn()
 
 
 def prior_rnn():
+    ___shape = {}
+    ___shape['input'] = n_characters
+    ___shape['target'] = n_characters
     prior_rnn = {}
-    prior_rnn['encoder.weight'] = dist.Normal(tensor(0), tensor(1))
-    prior_rnn['gru.weight_ih_l0'] = dist.Normal(tensor(0), tensor(1))
-    prior_rnn['gru.weight_hh_l0'] = dist.Normal(tensor(0), tensor(1))
-    prior_rnn['gru.bias_ih_l0'] = dist.Normal(tensor(0), tensor(1))
-    prior_rnn['gru.bias_hh_l0'] = dist.Normal(tensor(0), tensor(1))
-    prior_rnn['decoder.weight'] = dist.Normal(tensor(0), tensor(1))
-    prior_rnn['decoder.bias'] = dist.Normal(tensor(0), tensor(1))
+    prior_rnn['encoder.weight'] = dist.Normal(zeros(rnn.encoder.weight.shape()), ones(rnn.encoder.weight.shape()))
+    prior_rnn['gru.weight_ih_l0'] = dist.Normal(zeros(rnn.gru.weight_ih_l0.shape()), ones(rnn.gru.weight_ih_l0.shape()))
+    prior_rnn['gru.weight_hh_l0'] = dist.Normal(zeros(rnn.gru.weight_hh_l0.shape()), ones(rnn.gru.weight_hh_l0.shape()))
+    prior_rnn['gru.bias_ih_l0'] = dist.Normal(zeros(rnn.gru.bias_ih_l0.shape()), ones(rnn.gru.bias_ih_l0.shape()))
+    prior_rnn['gru.bias_hh_l0'] = dist.Normal(zeros(rnn.gru.bias_hh_l0.shape()), ones(rnn.gru.bias_hh_l0.shape()))
+    prior_rnn['decoder.weight'] = dist.Normal(zeros(rnn.decoder.weight.shape()), ones(rnn.decoder.weight.shape()))
+    prior_rnn['decoder.bias'] = dist.Normal(zeros(rnn.decoder.bias.shape()), ones(rnn.decoder.bias.shape()))
     lifted_rnn = pyro.random_module('rnn', rnn, prior_rnn)
     return lifted_rnn()
 
 
 def model(input, n_characters, target):
+    ___shape = {}
+    ___shape['input'] = n_characters
+    ___shape['target'] = n_characters
     rnn = prior_rnn()
+    ___shape['logits'] = n_characters
     logits = rnn(input)
     pyro.sample('target', dist.Categorical(logits), obs=target)

--- a/deepppl/tests/target_py/mlp.py
+++ b/deepppl/tests/target_py/mlp.py
@@ -5,33 +5,55 @@ import pyro.distributions as dist
 
 
 def guide_mlp(batch_size, imgs, labels):
+    ___shape = {}
+    ___shape['imgs'] = [tensor(28), tensor(28), batch_size]
+    ___shape['labels'] = batch_size
+    ___shape['l1wloc'] = mlp.l1.weight.shape()
+    ___shape['l1wscale'] = mlp.l1.weight.shape()
+    ___shape['l1bloc'] = mlp.l1.bias.shape()
+    ___shape['l1bscale'] = mlp.l1.bias.shape()
+    ___shape['l2wloc'] = mlp.l2.weight.shape()
+    ___shape['l2wscale'] = mlp.l2.weight.shape()
+    ___shape['l2bloc'] = mlp.l2.bias.shape()
+    ___shape['l2bscale'] = mlp.l2.bias.shape()
     guide_mlp = {}
-    l1wloc = pyro.param('l1wloc', randn(tensor(0), tensor(1)))
-    l1wscale = pyro.param('l1wscale', exp(randn()))
+    l1wloc = pyro.param('l1wloc', randn(___shape['l1wloc']))
+    l1wscale = pyro.param('l1wscale', exp(randn(___shape['l1wscale'])))
     guide_mlp['l1.weight'] = dist.Normal(l1wloc, l1wscale)
-    l1bloc = pyro.param('l1bloc', randn(tensor(0), tensor(1)))
-    l1bscale = pyro.param('l1bscale', exp(randn()))
+    l1bloc = pyro.param('l1bloc', randn(___shape['l1bloc']))
+    l1bscale = pyro.param('l1bscale', exp(randn(___shape['l1bscale'])))
     guide_mlp['l1.bias'] = dist.Normal(l1bloc, l1bscale)
-    l2wloc = pyro.param('l2wloc', randn(tensor(0), tensor(1)))
-    l2wscale = pyro.param('l2wscale', exp(randn()))
+    l2wloc = pyro.param('l2wloc', randn(___shape['l2wloc']))
+    l2wscale = pyro.param('l2wscale', exp(randn(___shape['l2wscale'])))
     guide_mlp['l2.weight'] = dist.Normal(l2wloc, l2wscale)
-    l2bloc = pyro.param('l2bloc', randn())
-    l2bscale = pyro.param('l2bscale', exp(randn()))
+    l2bloc = pyro.param('l2bloc', randn(___shape['l2bloc']))
+    l2bscale = pyro.param('l2bscale', exp(randn(___shape['l2bscale'])))
     guide_mlp['l2.bias'] = dist.Normal(l2bloc, l2bscale)
     lifted_mlp = pyro.random_module('mlp', mlp, guide_mlp)
     return lifted_mlp()
 
 def prior_mlp():
+    ___shape = {}
+    ___shape['imgs'] = [tensor(28), tensor(28), batch_size]
+    ___shape['labels'] = batch_size
     prior_mlp = {}
-    prior_mlp['l1.weight'] = dist.Normal(tensor(0), tensor(1))
-    prior_mlp['l1.bias'] = dist.Normal(tensor(0), tensor(1))
-    prior_mlp['l2.weight'] = dist.Normal(tensor(0), tensor(1))
-    prior_mlp['l2.bias'] = dist.Normal(tensor(0), tensor(1))
+    prior_mlp['l1.weight'] = dist.Normal(zeros(mlp.l1.weight.shape()), ones
+        (mlp.l1.weight.shape()))
+    prior_mlp['l1.bias'] = dist.Normal(zeros(mlp.l1.bias.shape()), ones(mlp
+        .l1.bias.shape()))
+    prior_mlp['l2.weight'] = dist.Normal(zeros(mlp.l2.weight.shape()), ones
+        (mlp.l2.weight.shape()))
+    prior_mlp['l2.bias'] = dist.Normal(zeros(mlp.l2.bias.shape()), ones(mlp
+        .l2.bias.shape()))
     lifted_mlp = pyro.random_module('mlp', mlp, prior_mlp)
     return lifted_mlp()
 
 
 def model(batch_size, imgs, labels):
+    ___shape = {}
+    ___shape['imgs'] = [tensor(28), tensor(28), batch_size]
+    ___shape['labels'] = batch_size
     mlp = prior_mlp()
+    ___shape['logits'] = batch_size
     logits = mlp(imgs)
     pyro.sample('labels', dist.Categorical(logits), obs=labels)

--- a/deepppl/tests/target_py/mlp.py
+++ b/deepppl/tests/target_py/mlp.py
@@ -32,7 +32,7 @@ def guide_mlp(batch_size, imgs, labels):
     lifted_mlp = pyro.random_module('mlp', mlp, guide_mlp)
     return lifted_mlp()
 
-def prior_mlp():
+def prior_mlp(batch_size, imgs, labels):
     ___shape = {}
     ___shape['imgs'] = [tensor(28), tensor(28), batch_size]
     ___shape['labels'] = batch_size
@@ -53,7 +53,7 @@ def model(batch_size, imgs, labels):
     ___shape = {}
     ___shape['imgs'] = [tensor(28), tensor(28), batch_size]
     ___shape['labels'] = batch_size
-    mlp = prior_mlp()
+    mlp = prior_mlp(batch_size, imgs, labels)
     ___shape['logits'] = batch_size
     logits = mlp(imgs)
     pyro.sample('labels', dist.Categorical(logits), obs=labels)

--- a/deepppl/tests/target_py/operators-expr.py
+++ b/deepppl/tests/target_py/operators-expr.py
@@ -5,6 +5,8 @@ import pyro.distributions as dist
 
 
 def model(x):
+    ___shape = {}
+    ___shape['x'] = tensor(10)
     theta = pyro.sample('theta', dist.Uniform(tensor(0) * tensor(3) / tensor(5), tensor(1) + tensor(5) - tensor(5)))
     for i in range(tensor(1), tensor(10) + 1):
         if tensor(1) <= tensor(10) and (tensor(1) > tensor(5) or tensor(2) < tensor(1)):

--- a/deepppl/tests/target_py/operators.py
+++ b/deepppl/tests/target_py/operators.py
@@ -5,6 +5,8 @@ import pyro.distributions as dist
 
 
 def model(x):
+    ___shape = {}
+    ___shape['x'] = tensor(10)
     theta = pyro.sample('theta', dist.Uniform(tensor(0) * tensor(3) / tensor(5), tensor(1) + tensor(5) - tensor(5)))
     for i in range(tensor(1), tensor(10) + 1):
         if tensor(1) <= tensor(10) and (tensor(1) > tensor(5) or tensor(2) < tensor(1)):

--- a/deepppl/tests/target_py/vae.py
+++ b/deepppl/tests/target_py/vae.py
@@ -5,7 +5,9 @@ import pyro.distributions as dist
 
 
 def guide_(x):
-    pyro.module("encoder", encoder)
+    ___shape = {}
+    pyro.module('encoder', encoder)
+    ___shape['encoded'] = tensor(2)
     encoded = encoder(x)
     mu = encoded[tensor(1) - 1]
     sigma = encoded[tensor(2) - 1]
@@ -13,6 +15,7 @@ def guide_(x):
 
 
 def model(x):
+    ___shape = {}
     pyro.module("decoder", decoder)
     latent = pyro.sample('latent', dist.Normal(tensor(0), tensor(1)))
     loc_img = decoder(latent)

--- a/deepppl/tests/test_irl.py
+++ b/deepppl/tests/test_irl.py
@@ -72,6 +72,12 @@ def test_coin_guide():
     normalize_and_compare(filename, target_file)
 
 
+def test_lstm():
+    filename = r'deepppl/tests/good/lstm.stan'
+    target_file = r'deepppl/tests/target_py/lstm.py'
+    normalize_and_compare(filename, target_file)
+
+
 
 def test_coin_guide_missing_var():
     with pytest.raises(MissingGuideExeption):

--- a/deepppl/translation/ir.py
+++ b/deepppl/translation/ir.py
@@ -422,6 +422,15 @@ class Variable(Expression):
     def is_prior_var(self):
         return self.block_name == Prior.blockName()
 
+class VariableProperty(Expression):
+    def __init__(self, var = None, prop = None):
+        super(VariableProperty, self).__init__()
+        self.var = var
+        self.prop = prop
+
+class NetVariableProperty(VariableProperty):
+    pass
+
 class NetDeclaration(IR):
     def __init__(self, name = None, cls = None, params = []):
         super(NetDeclaration, self).__init__()

--- a/deepppl/translation/ir2python.py
+++ b/deepppl/translation/ir2python.py
@@ -160,7 +160,7 @@ class NetworkVisitor(IRVisitor):
         params = var.ids
         assert net in self._nets
         assert params in self._nets[net].params, "Use of undeclared network parameters: {}."\
-                                            .format(var)
+                                            .format('.'.join([net] + params))
         self._currdict[net].remove(self._param_to_name(params))
         return var
 

--- a/deepppl/translation/ir2python.py
+++ b/deepppl/translation/ir2python.py
@@ -688,9 +688,12 @@ class Ir2PythonVisitor(IRVisitor):
         pre_body = self.liftBlackBox(prior)
         inner_body = self.liftBody(prior, name, name_prior)
         body = self._model_header + pre_body + inner_body
-        f = self._funcDef(name = name_prior, body = body)
+        f = self._funcDef(name = name_prior, args = self.modelArgs(), body = body)
         self._priors = {name : name_prior}
         return f
+
+    def modelArgsAsParams(self):
+        return [self.loadName(name) for name in sorted(self.data_names)]
 
 
     def visitGuide(self, guide):
@@ -720,7 +723,11 @@ class Ir2PythonVisitor(IRVisitor):
         for prior in self._priors:
             pre_body.append(
                 self._assign(self.loadName(prior),
-                             self.call(self.loadName(self._priors[prior])))
+                             self.call(
+                                        id = self.loadName(self._priors[prior]),
+                                        args = self.modelArgsAsParams()
+                                        )
+                            )
             )
         body = self._model_header + pre_body + inner_body
         model = self._funcDef(

--- a/deepppl/translation/stan2ir.py
+++ b/deepppl/translation/stan2ir.py
@@ -100,6 +100,10 @@ class StanToIR(stanListener):
             name = ctx.atom().ir
             index = ctx.indexExpression().ir
             ctx.ir = Subscript(id = name, index = index)
+        elif is_active(ctx.netLValue):
+            ctx.ir = ctx.netLValue().ir
+        elif is_active(ctx.variableProperty):
+            ctx.ir = ctx.variableProperty().ir
         else:
             assert False, "Not yet implemented atom: {}".format(ctx.getText())
 
@@ -238,6 +242,19 @@ class StanToIR(stanListener):
         name = ctx.netName().getText()
         ids = ctx.netParam().ir
         ctx.ir = NetVariable(name = name, ids = ids)
+
+    def exitVariableProperty(self, ctx):
+        property = ctx.IDENTIFIER().getText()
+        if is_active(ctx.netLValue):
+            var = ctx.netLValue().ir
+            cls = NetVariableProperty
+        elif is_active(ctx.variable):
+            var = ctx.variable().ir
+            cls = VariableProperty
+        else:
+            assert False, "Not yet implemented."
+        
+        ctx.ir = cls(var = var, prop= property)
 
     def exitSamplingStmt(self, ctx):
         lvalue = ctx.lvalueSampling().ir

--- a/deepppl/translation/stan2ir.py
+++ b/deepppl/translation/stan2ir.py
@@ -63,7 +63,11 @@ class StanToIR(stanListener):
         ctx.ir = VariableDecl(id = vid, dim = dims)
 
     def exitArrayDim(self, ctx):
-        ctx.ir = List(elements = ctx.expressionCommaList().ir)
+        elements = ctx.expressionCommaList().ir
+        if len(elements) == 1:
+            ctx.ir = elements[0]
+        else:
+            ctx.ir = List(elements = elements)
 
     def exitVariableDeclsOpt(self, ctx):
         ctx.ir = gatherChildrenIR(ctx)


### PR DESCRIPTION
* Now the user can query the shape of a variable using the dollar sign:

```
some_var = randn(mlp.weights$shape);
```
* Blocks `data`, `parameters` and `guide_parameters` are _headers_ for `model`, `guide` and `prior`. For instance, the shape definition of a variable defined in the `parameter` block will be include in the three blocks: `model`, `guide` and `prior` if they all appear.

* The function defined for the `prior` block receives the same arguments as `model` and `data`