### PR TITLE
New nn priors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 dist: xenial
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get install -y antlr4
 install:
   - pip install --upgrade pip
-  - pip install -r deepppl/requirements.txt #--progress-bar off
+  - pip install -r deepppl/requirements.txt --progress-bar off
 # command to run tests
 before_script:
   - cd deepppl

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get install -y antlr4
 install:
   - pip install --upgrade pip
-  - pip install -r deepppl/requirements.txt --progress-bar off
+  - pip install -r deepppl/requirements.txt #--progress-bar off
 # command to run tests
 before_script:
   - cd deepppl

--- a/deepppl/parser/stan.g4
+++ b/deepppl/parser/stan.g4
@@ -148,7 +148,6 @@ FUNCTIONS: 'functions';
 MODEL: 'model';
 DATA: 'data';
 NETWORKS: 'networks';
-PRIOR: 'prior';
 GUIDE: 'guide';
 PARAMETERS: 'parameters';
 QUANTITIES: 'quantities';
@@ -603,10 +602,6 @@ networksBlock
     : NETWORKS '{' netVariableDeclsOpt '}'
     ;
 
-priorBlock
-    : PRIOR '{' samplingStmt* '}'
-    ;
-
 guideBlock
     : GUIDE '{' variableDeclsOpt statementsOpt '}'
     ;
@@ -643,7 +638,6 @@ program
         transformedDataBlock?
         parametersBlock?
         transformedParametersBlock?
-        priorBlock?
         guideParametersBlock?
         guideBlock?
         modelBlock?

--- a/deepppl/tests/good/lstm.stan
+++ b/deepppl/tests/good/lstm.stan
@@ -35,16 +35,6 @@ parameters {
     real[] rnn.decoder.bias;
 }
 
-prior {
-    rnn.encoder.weight ~  Normal(zeros(rnn.encoder.weight$shape), ones(rnn.encoder.weight$shape));
-    rnn.gru.weight_ih_l0 ~ Normal(zeros(rnn.gru.weight_ih_l0$shape), ones(rnn.gru.weight_ih_l0$shape));
-    rnn.gru.weight_hh_l0 ~ Normal(zeros(rnn.gru.weight_hh_l0$shape), ones(rnn.gru.weight_hh_l0$shape));
-    rnn.gru.bias_ih_l0 ~  Normal(zeros(rnn.gru.bias_ih_l0$shape), ones(rnn.gru.bias_ih_l0$shape));
-    rnn.gru.bias_hh_l0 ~  Normal(zeros(rnn.gru.bias_hh_l0$shape), ones(rnn.gru.bias_hh_l0$shape));
-    rnn.decoder.weight ~  Normal(zeros(rnn.decoder.weight$shape), ones(rnn.decoder.weight$shape));
-    rnn.decoder.bias ~  Normal(zeros(rnn.decoder.bias$shape), ones(rnn.decoder.bias$shape));
-}
-
 guide parameters {
     real ewl[rnn.encoder.weight$shape];
     real ews[rnn.encoder.weight$shape];
@@ -89,6 +79,13 @@ guide {
 
 model {
     int logits[n_characters];
+    rnn.encoder.weight ~  Normal(zeros(rnn.encoder.weight$shape), ones(rnn.encoder.weight$shape));
+    rnn.gru.weight_ih_l0 ~ Normal(zeros(rnn.gru.weight_ih_l0$shape), ones(rnn.gru.weight_ih_l0$shape));
+    rnn.gru.weight_hh_l0 ~ Normal(zeros(rnn.gru.weight_hh_l0$shape), ones(rnn.gru.weight_hh_l0$shape));
+    rnn.gru.bias_ih_l0 ~  Normal(zeros(rnn.gru.bias_ih_l0$shape), ones(rnn.gru.bias_ih_l0$shape));
+    rnn.gru.bias_hh_l0 ~  Normal(zeros(rnn.gru.bias_hh_l0$shape), ones(rnn.gru.bias_hh_l0$shape));
+    rnn.decoder.weight ~  Normal(zeros(rnn.decoder.weight$shape), ones(rnn.decoder.weight$shape));
+    rnn.decoder.bias ~  Normal(zeros(rnn.decoder.bias$shape), ones(rnn.decoder.bias$shape));
     logits = rnn(input);
     category ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/lstm_modified.stan
+++ b/deepppl/tests/good/lstm_modified.stan
@@ -29,9 +29,6 @@ parameters {
     real[] rnn.encoder.weight;
 }
 
-prior {
-     rnn.encoder.weight ~  Normal(zeros(rnn.encoder.weight$shape), ones(rnn.encoder.weight$shape));
-}
 
 guide parameters {
      real ewl[rnn.encoder.weight$shape];
@@ -46,6 +43,7 @@ guide {
 
 model {
     int logits[n_characters];
+    rnn.encoder.weight ~  Normal(zeros(rnn.encoder.weight$shape), ones(rnn.encoder.weight$shape));
     logits = rnn(input);
     category ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/mlp.stan
+++ b/deepppl/tests/good/mlp.stan
@@ -32,13 +32,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
-}
-
 guide parameters {
     real l1wloc[mlp.l1.weight$shape];
     real l1wscale[mlp.l1.weight$shape];
@@ -67,6 +60,11 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
+
     logits = mlp(imgs);
     labels ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/mlp_incorrect_shape1.stan
+++ b/deepppl/tests/good/mlp_incorrect_shape1.stan
@@ -32,17 +32,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-//    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.weight ~  Normal(zeros(), ones());
-//    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l1.bias ~ Normal(zeros(), ones());
-//    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.weight ~ Normal(zeros(), ones());
-//    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));   //<- First argument has a different shape>
-    mlp.l2.bias ~  Normal(zeros(), ones());   //<- First argument has a different shape>
-}
-
 guide parameters {
     real l1wloc[mlp.l1.weight$shape];
     real l1wscale[mlp.l1.weight$shape];
@@ -71,6 +60,15 @@ guide {
 
 model {
     real logits[batch_size];
+//    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.weight ~  Normal(zeros(), ones());
+//    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l1.bias ~ Normal(zeros(), ones());
+//    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.weight ~ Normal(zeros(), ones());
+//    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));   //<- First argument has a different shape>
+    mlp.l2.bias ~  Normal(zeros(), ones());   //<- First argument has a different shape>
+
     logits = mlp(imgs);
     labels ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/mlp_incorrect_shape2.stan
+++ b/deepppl/tests/good/mlp_incorrect_shape2.stan
@@ -32,12 +32,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l1.bias$shape));   // <- second argument has a different shape>
-}
 
 guide parameters {
     real l1wloc[mlp.l1.weight$shape];
@@ -66,7 +60,12 @@ guide {
 }
 
 model {
-    real logits[batch_size];
+    real logits[batch_size];    
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l1.bias$shape));   // <- second argument has a different shape>
+
     logits = mlp(imgs);
     labels ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/mlp_incorrect_shape3.stan
+++ b/deepppl/tests/good/mlp_incorrect_shape3.stan
@@ -32,12 +32,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
-}
 
 guide parameters {
     real l1wloc[mlp.l1.weight$shape];
@@ -67,6 +61,11 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
+
     logits = mlp(imgs);
     labels ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/mlp_incorrect_shape4.stan
+++ b/deepppl/tests/good/mlp_incorrect_shape4.stan
@@ -32,12 +32,7 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
-}
+
 
 guide parameters {
     real l1wloc[mlp.l1.weight$shape];
@@ -67,6 +62,10 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
     logits = mlp(imgs);
     labels ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/mlp_missing_guide.stan
+++ b/deepppl/tests/good/mlp_missing_guide.stan
@@ -32,13 +32,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-    mlp.l1.weight ~  Normal(0, 1);
-    mlp.l1.bias ~ Normal(0, 1);
-    mlp.l2.weight ~ Normal(0, 1);
-    mlp.l2.bias ~  Normal(0, 1);
-}
-
 guide parameters {
     real l1wloc;
     real l1wscale;
@@ -67,6 +60,10 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(0, 1);
+    mlp.l1.bias ~ Normal(0, 1);
+    mlp.l2.weight ~ Normal(0, 1);
+    mlp.l2.bias ~  Normal(0, 1);
     logits = mlp(imgs);
     labels ~ Categorical(logits);
 }

--- a/deepppl/tests/good/mlp_missing_model.stan
+++ b/deepppl/tests/good/mlp_missing_model.stan
@@ -32,14 +32,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior
-{
-    mlp.l1.weight ~  Normal(0, 1);
-    mlp.l1.bias ~ Normal(0, 1);
-    mlp.l2.weight ~ Normal(0, 1);
-    // mlp.l2.bias ~  Normal(0, 1);
-}
-
 guide parameters
 {
     real l1wloc;
@@ -69,6 +61,10 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(0, 1);
+    mlp.l1.bias ~ Normal(0, 1);
+    mlp.l2.weight ~ Normal(0, 1);
+    // mlp.l2.bias ~  Normal(0, 1);
     logits = mlp(imgs);
     labels ~ Categorical(logits);
 }

--- a/deepppl/tests/good/mlp_undeclared_net.stan
+++ b/deepppl/tests/good/mlp_undeclared_net.stan
@@ -31,12 +31,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
-}
 
 guide parameters {
     real l1wloc[mlp.l1.weight$shape];
@@ -66,6 +60,11 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
+
     logits = mlp(imgs);
     labels ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/mlp_undeclared_net1.stan
+++ b/deepppl/tests/good/mlp_undeclared_net1.stan
@@ -31,12 +31,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
-}
 
 guide parameters {
     real l1wloc[mlp.l1.weight$shape];
@@ -66,6 +60,11 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
+
     logits = mlp(imgs);
     labels ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/mlp_undeclared_net2.stan
+++ b/deepppl/tests/good/mlp_undeclared_net2.stan
@@ -32,13 +32,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
-}
-
 guide parameters {
     real l1wloc[mlp.l1.weight$shape];
     real l1wscale[mlp.l1.weight$shape];
@@ -67,6 +60,11 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
+
     logits = mlp(imgs);
     labels ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/mlp_undeclared_parameters.stan
+++ b/deepppl/tests/good/mlp_undeclared_parameters.stan
@@ -32,13 +32,6 @@ parameters {
    // real[] mlp.l2.bias;     <- Not declared
 }
 
-prior {
-    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
-}
-
 guide parameters {
     real l1wloc[mlp.l1.weight$shape];
     real l1wscale[mlp.l1.weight$shape];
@@ -67,6 +60,11 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
+
     logits = mlp(imgs);
     labels ~ CategoricalLogits(logits);
 }

--- a/deepppl/tests/good/mlp_unsupported_prop.stan
+++ b/deepppl/tests/good/mlp_unsupported_prop.stan
@@ -32,13 +32,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
-}
-
 guide parameters {
     real l1wloc[mlp.l1.weight$length];   // <--- should be shape
     real l1wscale[mlp.l1.weight$shape];
@@ -67,6 +60,10 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
     logits = mlp(imgs);
     labels ~ Categorical(logits);
 }

--- a/deepppl/tests/good/mlp_unsupported_prop1.stan
+++ b/deepppl/tests/good/mlp_unsupported_prop1.stan
@@ -32,13 +32,6 @@ parameters {
     real[] mlp.l2.bias;
 }
 
-prior {
-    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
-    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
-    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
-    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
-}
-
 guide parameters {
     real l1wloc[mlp.l1.weight$shape];
     real l1wscale[mlp.l1.weight$shape];
@@ -67,6 +60,11 @@ guide {
 
 model {
     real logits[batch_size];
+    mlp.l1.weight ~  Normal(zeros(mlp.l1.weight$shape), ones(mlp.l1.weight$shape));
+    mlp.l1.bias ~ Normal(zeros(mlp.l1.bias$shape), ones(mlp.l1.bias$shape));
+    mlp.l2.weight ~ Normal(zeros(mlp.l2.weight$shape), ones(mlp.l2.weight$shape));
+    mlp.l2.bias ~  Normal(zeros(mlp.l2.bias$shape), ones(mlp.l2.bias$shape));
+
     logits = mlp(imgs);
     labels ~ Categorical(logits);
 }

--- a/deepppl/tests/target_py/lstm.py
+++ b/deepppl/tests/target_py/lstm.py
@@ -53,20 +53,13 @@ def prior_rnn(category, input, n_characters):
     ___shape['input'] = n_characters
     ___shape['category'] = n_characters
     prior_rnn = {}
-    prior_rnn['encoder.weight'] = dist.Normal(zeros(rnn.encoder.weight.
-        shape), ones(rnn.encoder.weight.shape))
-    prior_rnn['gru.weight_ih_l0'] = dist.Normal(zeros(rnn.gru.weight_ih_l0.
-        shape), ones(rnn.gru.weight_ih_l0.shape))
-    prior_rnn['gru.weight_hh_l0'] = dist.Normal(zeros(rnn.gru.weight_hh_l0.
-        shape), ones(rnn.gru.weight_hh_l0.shape))
-    prior_rnn['gru.bias_ih_l0'] = dist.Normal(zeros(rnn.gru.bias_ih_l0.
-        shape), ones(rnn.gru.bias_ih_l0.shape))
-    prior_rnn['gru.bias_hh_l0'] = dist.Normal(zeros(rnn.gru.bias_hh_l0.
-        shape), ones(rnn.gru.bias_hh_l0.shape))
-    prior_rnn['decoder.weight'] = dist.Normal(zeros(rnn.decoder.weight.
-        shape), ones(rnn.decoder.weight.shape))
-    prior_rnn['decoder.bias'] = dist.Normal(zeros(rnn.decoder.bias.shape),
-        ones(rnn.decoder.bias.shape))
+    prior_rnn['encoder.weight'] = ImproperUniform(rnn.encoder.weight.shape)
+    prior_rnn['gru.weight_ih_l0'] = ImproperUniform(rnn.gru.weight_ih_l0.shape)
+    prior_rnn['gru.weight_hh_l0'] = ImproperUniform(rnn.gru.weight_hh_l0.shape)
+    prior_rnn['gru.bias_ih_l0'] = ImproperUniform(rnn.gru.bias_ih_l0.shape)
+    prior_rnn['gru.bias_hh_l0'] = ImproperUniform(rnn.gru.bias_hh_l0.shape)
+    prior_rnn['decoder.weight'] = ImproperUniform(rnn.decoder.weight.shape)
+    prior_rnn['decoder.bias'] = ImproperUniform(rnn.decoder.bias.shape)
     lifted_rnn = pyro.random_module('rnn', rnn, prior_rnn)
     return lifted_rnn()
 
@@ -76,6 +69,28 @@ def model(category, input, n_characters):
     ___shape['input'] = n_characters
     ___shape['category'] = n_characters
     rnn = prior_rnn(category, input, n_characters)
+    model_rnn = rnn.state_dict()
     ___shape['logits'] = n_characters
+    pyro.sample('model_rnn' + '{}'.format('encoder.weight') + '1', dist.
+        Normal(zeros(rnn.encoder.weight.shape), ones(rnn.encoder.weight.
+        shape)), obs=model_rnn['encoder.weight'])
+    pyro.sample('model_rnn' + '{}'.format('gru.weight_ih_l0') + '2', dist.
+        Normal(zeros(rnn.gru.weight_ih_l0.shape), ones(rnn.gru.weight_ih_l0
+        .shape)), obs=model_rnn['gru.weight_ih_l0'])
+    pyro.sample('model_rnn' + '{}'.format('gru.weight_hh_l0') + '3', dist.
+        Normal(zeros(rnn.gru.weight_hh_l0.shape), ones(rnn.gru.weight_hh_l0
+        .shape)), obs=model_rnn['gru.weight_hh_l0'])
+    pyro.sample('model_rnn' + '{}'.format('gru.bias_ih_l0') + '4', dist.
+        Normal(zeros(rnn.gru.bias_ih_l0.shape), ones(rnn.gru.bias_ih_l0.
+        shape)), obs=model_rnn['gru.bias_ih_l0'])
+    pyro.sample('model_rnn' + '{}'.format('gru.bias_hh_l0') + '5', dist.
+        Normal(zeros(rnn.gru.bias_hh_l0.shape), ones(rnn.gru.bias_hh_l0.
+        shape)), obs=model_rnn['gru.bias_hh_l0'])
+    pyro.sample('model_rnn' + '{}'.format('decoder.weight') + '6', dist.
+        Normal(zeros(rnn.decoder.weight.shape), ones(rnn.decoder.weight.
+        shape)), obs=model_rnn['decoder.weight'])
+    pyro.sample('model_rnn' + '{}'.format('decoder.bias') + '7', dist.
+        Normal(zeros(rnn.decoder.bias.shape), ones(rnn.decoder.bias.shape)),
+        obs=model_rnn['decoder.bias'])
     logits = rnn(input)
-    pyro.sample('category' + '1', CategoricalLogits(logits), obs=category)
+    pyro.sample('category' + '8', CategoricalLogits(logits), obs=category)

--- a/deepppl/tests/target_py/mlp.py
+++ b/deepppl/tests/target_py/mlp.py
@@ -38,14 +38,10 @@ def prior_mlp(batch_size, imgs, labels):
     ___shape['imgs'] = [tensor(28), tensor(28), batch_size]
     ___shape['labels'] = batch_size
     prior_mlp = {}
-    prior_mlp['l1.weight'] = dist.Normal(zeros(mlp.l1.weight.shape), ones(
-        mlp.l1.weight.shape))
-    prior_mlp['l1.bias'] = dist.Normal(zeros(mlp.l1.bias.shape), ones(mlp.
-        l1.bias.shape))
-    prior_mlp['l2.weight'] = dist.Normal(zeros(mlp.l2.weight.shape), ones(
-        mlp.l2.weight.shape))
-    prior_mlp['l2.bias'] = dist.Normal(zeros(mlp.l2.bias.shape), ones(mlp.
-        l2.bias.shape))
+    prior_mlp['l1.weight'] = ImproperUniform(mlp.l1.weight.shape)
+    prior_mlp['l1.bias'] = ImproperUniform(mlp.l1.bias.shape)
+    prior_mlp['l2.weight'] = ImproperUniform(mlp.l2.weight.shape)
+    prior_mlp['l2.bias'] = ImproperUniform(mlp.l2.bias.shape)
     lifted_mlp = pyro.random_module('mlp', mlp, prior_mlp)
     return lifted_mlp()
 
@@ -55,6 +51,19 @@ def model(batch_size, imgs, labels):
     ___shape['imgs'] = [tensor(28), tensor(28), batch_size]
     ___shape['labels'] = batch_size
     mlp = prior_mlp(batch_size, imgs, labels)
+    model_mlp = mlp.state_dict()
     ___shape['logits'] = batch_size
+    pyro.sample('model_mlp' + '{}'.format('l1.weight') + '1', dist.Normal(
+        zeros(mlp.l1.weight.shape), ones(mlp.l1.weight.shape)), obs=
+        model_mlp['l1.weight'])
+    pyro.sample('model_mlp' + '{}'.format('l1.bias') + '2', dist.Normal(
+        zeros(mlp.l1.bias.shape), ones(mlp.l1.bias.shape)), obs=model_mlp[
+        'l1.bias'])
+    pyro.sample('model_mlp' + '{}'.format('l2.weight') + '3', dist.Normal(
+        zeros(mlp.l2.weight.shape), ones(mlp.l2.weight.shape)), obs=
+        model_mlp['l2.weight'])
+    pyro.sample('model_mlp' + '{}'.format('l2.bias') + '4', dist.Normal(
+        zeros(mlp.l2.bias.shape), ones(mlp.l2.bias.shape)), obs=model_mlp[
+        'l2.bias'])
     logits = mlp(imgs)
-    pyro.sample('labels' + '1', CategoricalLogits(logits), obs=labels)
+    pyro.sample('labels' + '5', CategoricalLogits(logits), obs=labels)

--- a/deepppl/tests/test_irl.py
+++ b/deepppl/tests/test_irl.py
@@ -147,7 +147,7 @@ def test_mlp_missing_guide():
         dpplc.stan2astpyFile(filename)
 
 def test_mlp_missing_model():
-    with pytest.raises(MissingPriorNetException):
+    with not_raises(MissingPriorNetException):
         filename = r'deepppl/tests/good/mlp_missing_model.stan'
         dpplc.stan2astpyFile(filename)
 

--- a/deepppl/translation/ir2python.py
+++ b/deepppl/translation/ir2python.py
@@ -24,7 +24,8 @@ from .ir import NetVariable, Program, ForStmt, ConditionalStmt, \
                 AssignStmt, Subscript, BlockStmt,\
                 CallStmt, List, SamplingDeclaration, SamplingObserved,\
                 SamplingParameters, Variable, Constant, BinaryOperator, \
-                Minus, UnaryOperator, UMinus, AnonymousShapeProperty
+                Minus, UnaryOperator, UMinus, AnonymousShapeProperty,\
+                NetVariableProperty, Prior
 
 from .exceptions import *
 
@@ -109,10 +110,11 @@ class VariableAnnotationsVisitor(IRVisitor):
     def visitSamplingStmt(self, sampling):
         target = sampling.target.accept(self)
         args = self._visitAll(sampling.args)
-        if (self.block.is_prior() or self.block.is_guide()) and target.is_net_var():
-            method = SamplingDeclaration
-        elif self.block.is_guide() and not target.is_net_var():
-            method = SamplingParameters
+        if self.block.is_guide():
+            if target.is_net_var():
+                method = SamplingDeclaration
+            else:
+                method = SamplingParameters
         else:
             method = SamplingObserved
         return method(target = target, args = args, id = sampling.id)
@@ -205,6 +207,7 @@ class NetworksVisitor(IRVisitor):
         self._priors = {}
         self._guides = {}
         self._shouldRemove = False
+        self._shouldAddNetPrior = False
 
     def defaultVisit(self, node):
         answer = node
@@ -214,6 +217,9 @@ class NetworksVisitor(IRVisitor):
     def visitProgram(self, program):
         answer = Program()
         answer.children = self._visitChildren(program)
+        if self._shouldAddNetPrior:
+            prior = self.netPrior()
+            answer.prior = prior.accept(self)
         return answer
 
     def visitSamplingBlock(self, sampling):
@@ -226,29 +232,33 @@ class NetworksVisitor(IRVisitor):
     visitSamplingDeclaration = visitSamplingBlock
     visitSamplingParameters = visitSamplingBlock
 
+    def is_on_model(self):
+        return self._currBlock and self._currBlock.is_model()
+
     def visitNetVariable(self, var):
         net = var.name
         params = var.ids
         if not net in self._nets:
             raise UndeclaredNetworkException(net)
         if not params in self._nets[net].params:
-            raise UndeclaredParametersException('.'.join([net] + params))
-        if self._shouldRemove:
-            self._currdict[net].remove(self._param_to_name(params))
+            raise UndeclaredParametersException(params.id)
+        if self._shouldRemove and not self.is_on_model():
+            del self._currdict[net][var.id]
         return var
 
-    def visitPrior(self, prior):
-        self._currdict = self._priors
-        self._currBlock = prior
-        nets = [net for net in self._currdict if self._currdict[net]]
-        prior.children = self._visitChildren(prior)
-        prior._nets = nets
-        for net in self._currdict:
-            params = self._currdict[net]
-            if params:
-                raise MissingPriorNetException(net, params)
-        self._currdict = None
-        self._currBlock = None
+    def netPrior(self):
+        body = []
+        prior = Prior(body = body)
+        for net in self._priors:
+            for var in self._priors[net].values():
+                shape = NetVariableProperty(var = var, prop = 'shape')
+                sampling = SamplingDeclaration(
+                            target = var,
+                            id  = 'ImproperUniform',
+                            args = [shape]
+                        )
+                var.block_name = prior.blockName()
+                body.append(sampling)
         return prior
 
     def visitModel(self, model):
@@ -265,20 +275,25 @@ class NetworksVisitor(IRVisitor):
                 self._currBlock._blackBoxNets.add(call.id)
         return call
 
+    def visitPrior(self, prior):
+        return self._visitGenerativeBlock(prior, self._priors, MissingPriorNetException)
 
     def visitGuide(self, guide):
-        self._currdict = self._guides
-        self._currBlock = guide
+        return self._visitGenerativeBlock(guide, self._guides, MissingGuideNetException)
+
+    def _visitGenerativeBlock(self, block, dict, exception):
+        self._currdict = dict
+        self._currBlock = block
         nets = [net for net in self._currdict if self._currdict[net]]
-        guide.children = self._visitChildren(guide)
-        guide._nets = nets
+        block.children = self._visitChildren(block)
+        block._nets = nets
         for net in self._currdict:
             params = self._currdict[net]
             if params:
-                raise MissingGuideNetException(net, params)
+                raise exception(net, params)
         self._currdict = None
         self._currBlock = None
-        return guide
+        return block
         
     def _param_to_name(self, params):
         return '.'.join(params)
@@ -287,8 +302,11 @@ class NetworksVisitor(IRVisitor):
         name = decl.name
         self._nets[name] = decl
         if decl.params:
-            self._guides[name] = set([self._param_to_name(x) for x in decl.params])
-            self._priors[name] = set([self._param_to_name(x) for x in decl.params])
+            vars = [NetVariable(name = name, ids = x) 
+                                            for x in decl.params]
+            self._guides[name] = {var.id: var for var in vars}
+            self._priors[name] = {var.id: var for var in vars}
+            self._shouldAddNetPrior = True
         return decl
 
 

--- a/deepppl/translation/ir2python.py
+++ b/deepppl/translation/ir2python.py
@@ -241,7 +241,7 @@ class NetworksVisitor(IRVisitor):
         if not net in self._nets:
             raise UndeclaredNetworkException(net)
         if not params in self._nets[net].params:
-            raise UndeclaredParametersException(params.id)
+            raise UndeclaredParametersException('.'.join(params))
         if self._shouldRemove and not self.is_on_model():
             del self._currdict[net][var.id]
         return var
@@ -585,9 +585,13 @@ class ShapeCheckingVisitor(IRVisitor):
         return self._nets[name]
 
     def visitSamplingDeclaration(self, sampling):
-        target_shape = sampling.target.accept(self)
-        ### XXX check that all are the same
-        [x.accept(self).pointTo(target_shape) for x in sampling.args]
+        if sampling.target.is_net_var():
+            target_shape = sampling.target.accept(self)
+            
+            ### XXX check that all are the same
+            [x.accept(self).pointTo(target_shape) for x in sampling.args]
+
+    visitSamplingObserved = visitSamplingDeclaration
 
     def visitCallStmt(self, call):
         if call.id in self.known_functions:


### PR DESCRIPTION
Use new compilation schema for the NN's prior: they are not a proper section but instead they are initialized with the `ImproperUniform`
The generated code for the MLP now looks like this (the `guide` was omitted):
```python
def prior_mlp(batch_size, imgs, labels):
    ___shape = {}
    ___shape['imgs'] = [tensor(28), tensor(28), batch_size]
    ___shape['labels'] = batch_size
    prior_mlp = {}
    prior_mlp['l1.weight'] = ImproperUniform(mlp.l1.weight.shape)
    prior_mlp['l1.bias'] = ImproperUniform(mlp.l1.bias.shape)
    prior_mlp['l2.weight'] = ImproperUniform(mlp.l2.weight.shape)
    prior_mlp['l2.bias'] = ImproperUniform(mlp.l2.bias.shape)
    lifted_mlp = pyro.random_module('mlp', mlp, prior_mlp)
    return lifted_mlp()


def model(batch_size, imgs, labels):
    ___shape = {}
    ___shape['imgs'] = [tensor(28), tensor(28), batch_size]
    ___shape['labels'] = batch_size
    mlp = prior_mlp(batch_size, imgs, labels)
    model_mlp = mlp.state_dict()
    ___shape['logits'] = batch_size
    pyro.sample('model_mlp' + '{}'.format('l1.weight') + '1', dist.Normal(
        zeros(mlp.l1.weight.shape), ones(mlp.l1.weight.shape)), obs=
        model_mlp['l1.weight'])
    pyro.sample('model_mlp' + '{}'.format('l1.bias') + '2', dist.Normal(
        zeros(mlp.l1.bias.shape), ones(mlp.l1.bias.shape)), obs=model_mlp[
        'l1.bias'])
    pyro.sample('model_mlp' + '{}'.format('l2.weight') + '3', dist.Normal(
        zeros(mlp.l2.weight.shape), ones(mlp.l2.weight.shape)), obs=
        model_mlp['l2.weight'])
    pyro.sample('model_mlp' + '{}'.format('l2.bias') + '4', dist.Normal(
        zeros(mlp.l2.bias.shape), ones(mlp.l2.bias.shape)), obs=model_mlp[
        'l2.bias'])
    logits = mlp(imgs)
    pyro.sample('labels' + '5', CategoricalLogits(logits), obs=labels)
```